### PR TITLE
Propagate/notify device state changes to UrfKillswitch objects

### DIFF
--- a/src/urf-device.c
+++ b/src/urf-device.c
@@ -138,6 +138,8 @@ urf_device_update_states (UrfDevice      *device,
 		priv->soft = soft;
 		priv->hard = hard;
 		priv->state = event_to_state (priv->soft, priv->hard);
+
+		g_signal_emit (G_OBJECT (device), signals[SIGNAL_CHANGED], 0);
 		emit_properites_changed (device);
 		g_dbus_connection_emit_signal (priv->connection,
 		                               NULL,


### PR DESCRIPTION
I noticed killswitch changes to WLAN on my system did not get properly updated -- one I toggled WLAN to blocked with the killswitch input (Fn+F5 here), any new presses of Fn+F5 would still trigger setting the state to blocked.

I tracked it down to the UrfKillswitch object not updating its states because it was never getting the changed signal from UrfDevice.
