### PR TITLE
config: can't assume key_control to be enabled if there is no DMI inform...

### DIFF
--- a/src/urf-config.c
+++ b/src/urf-config.c
@@ -577,6 +577,13 @@ urf_config_load_profile (UrfConfig *config)
 	hardware_info = get_dmi_info ();
 	if (hardware_info == NULL) {
 		g_debug ("Failed to get DMI information");
+
+		/* If we don't have hardware info, then we can't assume key
+		 * control to be enabled: there would not be a way to disable
+		 * it for devices that don't have it.
+		 */
+		options->key_control = FALSE;
+
 		return;
 	}
 


### PR DESCRIPTION
...ation

Because otherwise, there won't be a way to actually disable it if it needs to
be disabled, since if it fails to start, the daemon aborts.

This happens on arm devices, we can't get hardware info because there is no DMI,
and without it there is no way to have key_control disabled by default.

Signed-off-by: Mathieu Trudel-Lapierre mathieu.trudel-lapierre@canonical.com
