### PR TITLE
Support logging to syslog

### DIFF
--- a/src/urf-arbitrator.c
+++ b/src/urf-arbitrator.c
@@ -106,7 +106,7 @@ urf_arbitrator_set_block (UrfArbitrator  *arbitrator,
 	event.type = type;
 	event.soft = block;
 
-	g_info ("Setting %s to %s", type_to_string (type), block?"blocked":"unblocked");
+	g_message ("Setting %s to %s", type_to_string (type), block?"blocked":"unblocked");
 	len = write (priv->fd, &event, sizeof(event));
 	if (len < 0) {
 		g_warning ("Failed to change RFKILL state: %s",
@@ -140,7 +140,7 @@ urf_arbitrator_set_block_idx (UrfArbitrator  *arbitrator,
 	event.idx = index;
 	event.soft = block;
 
-	g_info ("Setting device %u (%s) to %s",
+	g_message ("Setting device %u (%s) to %s",
 		index,
 		type_to_string (urf_device_get_rf_type (device)),
 		block ? "block" : "unblock");
@@ -310,7 +310,7 @@ remove_killswitch (UrfArbitrator *arbitrator,
 	object_path = g_strdup (urf_device_get_object_path(device));
 
 	name = urf_device_get_name (device);
-	g_info ("removing killswitch idx %d %s", index, name);
+	g_message ("removing killswitch idx %d %s", index, name);
 
 	urf_killswitch_del_device (priv->killswitch[type], device);
 	g_object_unref (device);
@@ -339,7 +339,7 @@ add_killswitch (UrfArbitrator *arbitrator,
 		return;
 	}
 
-	g_info ("adding killswitch idx %d soft %d hard %d", index, soft, hard);
+	g_message ("adding killswitch idx %d soft %d hard %d", index, soft, hard);
 
 	device = urf_device_new (index, type, soft, hard);
 	priv->devices = g_list_append (priv->devices, device);

--- a/src/urf-config.c
+++ b/src/urf-config.c
@@ -461,7 +461,7 @@ load_configured_settings (UrfConfig *config)
 					 G_KEY_FILE_NONE,
 					 NULL);
 	if (!ret) {
-		g_info ("No configured profile found");
+		g_message ("No configured profile found");
 		g_key_file_free (profile);
 		return FALSE;
 	}

--- a/src/urf-main.c
+++ b/src/urf-main.c
@@ -60,7 +60,7 @@ on_name_lost (GDBusConnection *connection,
 static gboolean
 urf_main_signal_cb (gpointer user_data)
 {
-	g_info ("Shutting down...");
+	g_message ("Shutting down...");
 	g_main_loop_quit (loop);
 	return FALSE;
 }
@@ -211,7 +211,7 @@ main (gint argc, gchar **argv)
 				loop,
 				NULL);
 
-	g_info ("Starting urfkilld version %s", PACKAGE_VERSION);
+	g_message ("Starting urfkilld version %s", PACKAGE_VERSION);
 
 	/* start the daemon */
 	daemon = urf_daemon_new (config);


### PR DESCRIPTION
And add --debug, which allows logging stuff at the GLib G_LOG_LEVEL_DEBUG level to also go to syslog.

Changes to the message log levels are suggested; what seems to me as being what people are most likely to want to know about: adding a killswitch, removing a killswitch, or changing the state via the API.
