### PR TITLE
Change size check to only fail if less than RFKILL_EVENT_SIZE_V1 as n…

### DIFF
--- a/src/urf-arbitrator.c
+++ b/src/urf-arbitrator.c
@@ -587,7 +587,12 @@ urf_arbitrator_startup (UrfArbitrator *arbitrator,
 			break;
 		}
 
-		if (len != RFKILL_EVENT_SIZE_V1) {
+		/* There has been a change in the kernel that allows for an extra
+                 * byte in the rfkill event struct that tracks a reason field.
+		 * see commit id 14486c82612a177cb910980c70ba900827ca0894 for
+                 * more information
+		 */
+		if (len < RFKILL_EVENT_SIZE_V1) {
 			g_warning("Wrong size of RFKILL event\n");
 			continue;
 		}


### PR DESCRIPTION
…ew fields are being added to the struct

The relevant kernel change is: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=14486c82612a177cb910980c70ba900827ca0894